### PR TITLE
Fix: Resolves #30, allows rename of DatabaseUser username

### DIFF
--- a/api/v1alpha1/databaseuser_types.go
+++ b/api/v1alpha1/databaseuser_types.go
@@ -24,7 +24,6 @@ import (
 // DatabaseUserSpec defines the desired state of DatabaseUser
 type DatabaseUserSpec struct {
 	AdminConnection AdminConnectionRef `json:"adminConnection"`
-	// TODO: Block or allow the rename of a user (currently would just CREATE new one if changed)
 	// +kubebuilder:validation:MaxLength:=32
 	// +kubebuilder:validation:MinLength:=1
 	Username string `json:"username"`

--- a/config/crd/bases/mysql.apps.cuppett.dev_databaseusers.yaml
+++ b/config/crd/bases/mysql.apps.cuppett.dev_databaseusers.yaml
@@ -108,8 +108,6 @@ spec:
                     type: boolean
                 type: object
               username:
-                description: 'TODO: Block or allow the rename of a user (currently
-                  would just CREATE new one if changed)'
                 maxLength: 32
                 minLength: 1
                 type: string

--- a/controllers/databaseuser_controller_test.go
+++ b/controllers/databaseuser_controller_test.go
@@ -94,13 +94,15 @@ var _ = Describe("DatabaseUser", func() {
 				return userObject.Status.Message
 			}).WithContext(ctx).Should(Equal("Created user"))
 
-			// Fetch a fresh DatabaseUser
-			err = k8sClient.Get(ctx, databaseNamespacedName, databaseUser)
-			Expect(err).ToNot(HaveOccurred())
-
-			databaseUser.Spec.Username = "test-user-renamed"
-			err = k8sClient.Update(ctx, databaseUser)
-			Expect(err).ToNot(HaveOccurred())
+			// Continue to do this until we stop getting 409.
+			Eventually(func() error {
+				// Fetch a fresh DatabaseUser
+				err = k8sClient.Get(ctx, databaseNamespacedName, databaseUser)
+				Expect(err).ToNot(HaveOccurred())
+				databaseUser.Spec.Username = "test-user-renamed"
+				err = k8sClient.Update(ctx, databaseUser)
+				return err
+			}).WithContext(ctx).Should(BeNil())
 
 			Eventually(func() string {
 				userObject := &DatabaseUser{}
@@ -149,14 +151,15 @@ var _ = Describe("DatabaseUser", func() {
 				return userObject.Status.Message
 			}).WithContext(ctx).Should(Equal("Created user"))
 
-			// Fetch a fresh DatabaseUser
-			err = k8sClient.Get(ctx, databaseNamespacedName, databaseUser)
-			Expect(err).ToNot(HaveOccurred())
-
-			// Update the username field
-			databaseUser.Spec.Username = "existing_user"
-			err = k8sClient.Update(ctx, databaseUser)
-			Expect(err).ToNot(HaveOccurred())
+			// Continue to do this until we stop getting 409.
+			Eventually(func() error {
+				// Fetch a fresh DatabaseUser
+				err = k8sClient.Get(ctx, databaseNamespacedName, databaseUser)
+				Expect(err).ToNot(HaveOccurred())
+				databaseUser.Spec.Username = "existing_user"
+				err = k8sClient.Update(ctx, databaseUser)
+				return err
+			}).WithContext(ctx).Should(BeNil())
 
 			Eventually(func() string {
 				userObject := &DatabaseUser{}
@@ -206,14 +209,15 @@ var _ = Describe("DatabaseUser", func() {
 				return userObject.Status.Message
 			}).WithContext(ctx).Should(Equal("Invalid username specified."))
 
-			// Fetch a fresh DatabaseUser
-			err = k8sClient.Get(ctx, databaseNamespacedName, databaseUser)
-			Expect(err).ToNot(HaveOccurred())
-
-			// Update the username field
-			databaseUser.Spec.Username = "switch-good-user"
-			err = k8sClient.Update(ctx, databaseUser)
-			Expect(err).ToNot(HaveOccurred())
+			// Continue to do this until we stop getting 409.
+			Eventually(func() error {
+				// Fetch a fresh DatabaseUser
+				err = k8sClient.Get(ctx, databaseNamespacedName, databaseUser)
+				Expect(err).ToNot(HaveOccurred())
+				databaseUser.Spec.Username = "switch-good-user"
+				err = k8sClient.Update(ctx, databaseUser)
+				return err
+			}).WithContext(ctx).Should(BeNil())
 
 			Eventually(func() string {
 				userObject := &DatabaseUser{}

--- a/controllers/databaseuser_controller_test.go
+++ b/controllers/databaseuser_controller_test.go
@@ -95,7 +95,6 @@ var _ = Describe("DatabaseUser", func() {
 			}).WithContext(ctx).Should(Equal("Created user"))
 
 			// Fetch a fresh DatabaseUser
-			databaseUser = &DatabaseUser{}
 			err = k8sClient.Get(ctx, databaseNamespacedName, databaseUser)
 			Expect(err).ToNot(HaveOccurred())
 
@@ -151,7 +150,6 @@ var _ = Describe("DatabaseUser", func() {
 			}).WithContext(ctx).Should(Equal("Created user"))
 
 			// Fetch a fresh DatabaseUser
-			databaseUser = &DatabaseUser{}
 			err = k8sClient.Get(ctx, databaseNamespacedName, databaseUser)
 			Expect(err).ToNot(HaveOccurred())
 
@@ -209,7 +207,6 @@ var _ = Describe("DatabaseUser", func() {
 			}).WithContext(ctx).Should(Equal("Invalid username specified."))
 
 			// Fetch a fresh DatabaseUser
-			databaseUser = &DatabaseUser{}
 			err = k8sClient.Get(ctx, databaseNamespacedName, databaseUser)
 			Expect(err).ToNot(HaveOccurred())
 
@@ -226,7 +223,6 @@ var _ = Describe("DatabaseUser", func() {
 			}).WithContext(ctx).Should(Equal("Created user"))
 
 			// Fetching again and checking the actual username.
-			databaseUser = &DatabaseUser{}
 			err = k8sClient.Get(ctx, databaseNamespacedName, databaseUser)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(databaseUser.Status.Username).To(Equal("switch-good-user"))

--- a/controllers/databaseuser_controller_test.go
+++ b/controllers/databaseuser_controller_test.go
@@ -1,6 +1,7 @@
 package controllers
 
 import (
+	"github.com/cuppett/mysql-dba-operator/orm"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -15,11 +16,9 @@ var _ = Describe("DatabaseUser", func() {
 
 	Describe("Creation Scenario", func() {
 
-		var databaseUser *DatabaseUser
-
 		It("Happy Path", func(ctx SpecContext) {
 
-			databaseUser = &DatabaseUser{
+			databaseUser := &DatabaseUser{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-user",
 					Namespace: ServerAdminConnection.Namespace,
@@ -48,4 +47,190 @@ var _ = Describe("DatabaseUser", func() {
 		}, NodeTimeout(time.Second*30))
 	})
 
+	Describe("Rename Scenario", func() {
+
+		It("Should have an existing user to rename", func(ctx SpecContext) {
+			// Pre-reqs
+			cache := make(map[types.UID]*orm.ConnectionDefinition)
+			gormDB, err := ServerAdminConnection.GetDatabaseConnection(ctx, k8sClient, cache)
+			Expect(err).ToNot(HaveOccurred())
+
+			// Create database user to be renamed
+			createQuery := "CREATE USER '" + Escape("existing_user") + "'"
+			tx := gormDB.Exec(createQuery)
+			Expect(tx.Error).To(BeNil())
+		})
+
+		It("Happy Path", func(ctx SpecContext) {
+
+			databaseNamespacedName := types.NamespacedName{
+				Name:      "test-user-name",
+				Namespace: ServerAdminConnection.Namespace,
+			}
+
+			databaseUser := &DatabaseUser{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-user-name",
+					Namespace: ServerAdminConnection.Namespace,
+				},
+				Spec: DatabaseUserSpec{
+					AdminConnection: AdminConnectionRef{
+						Name: ServerAdminConnection.Name,
+					},
+					Username: "test-user-name",
+				},
+			}
+			err := k8sClient.Create(ctx, databaseUser)
+			Expect(err).ToNot(HaveOccurred())
+
+			Eventually(func() string {
+				userObject := &DatabaseUser{}
+				databaseNamespacedName := types.NamespacedName{
+					Namespace: databaseUser.Namespace,
+					Name:      databaseUser.Name,
+				}
+				err := k8sClient.Get(ctx, databaseNamespacedName, userObject)
+				Expect(err).ToNot(HaveOccurred())
+				return userObject.Status.Message
+			}).WithContext(ctx).Should(Equal("Created user"))
+
+			// Fetch a fresh DatabaseUser
+			databaseUser = &DatabaseUser{}
+			err = k8sClient.Get(ctx, databaseNamespacedName, databaseUser)
+			Expect(err).ToNot(HaveOccurred())
+
+			databaseUser.Spec.Username = "test-user-renamed"
+			err = k8sClient.Update(ctx, databaseUser)
+			Expect(err).ToNot(HaveOccurred())
+
+			Eventually(func() string {
+				userObject := &DatabaseUser{}
+				err := k8sClient.Get(ctx, databaseNamespacedName, userObject)
+				Expect(err).ToNot(HaveOccurred())
+				return userObject.Status.Message
+			}).WithContext(ctx).Should(Equal("User renamed"))
+
+			// Fetching again and checking the actual username.
+			databaseUser = &DatabaseUser{}
+			err = k8sClient.Get(ctx, databaseNamespacedName, databaseUser)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(databaseUser.Status.Username).To(Equal("test-user-renamed"))
+
+		}, NodeTimeout(time.Second*30))
+
+		It("Fail Rename To Existing User", func(ctx SpecContext) {
+			databaseNamespacedName := types.NamespacedName{
+				Name:      "orig-user-name",
+				Namespace: ServerAdminConnection.Namespace,
+			}
+
+			databaseUser := &DatabaseUser{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "orig-user-name",
+					Namespace: ServerAdminConnection.Namespace,
+				},
+				Spec: DatabaseUserSpec{
+					AdminConnection: AdminConnectionRef{
+						Name: ServerAdminConnection.Name,
+					},
+					Username: "orig-user-name",
+				},
+			}
+			err := k8sClient.Create(ctx, databaseUser)
+			Expect(err).ToNot(HaveOccurred())
+
+			Eventually(func() string {
+				userObject := &DatabaseUser{}
+				databaseNamespacedName := types.NamespacedName{
+					Namespace: databaseUser.Namespace,
+					Name:      databaseUser.Name,
+				}
+				err := k8sClient.Get(ctx, databaseNamespacedName, userObject)
+				Expect(err).ToNot(HaveOccurred())
+				return userObject.Status.Message
+			}).WithContext(ctx).Should(Equal("Created user"))
+
+			// Fetch a fresh DatabaseUser
+			databaseUser = &DatabaseUser{}
+			err = k8sClient.Get(ctx, databaseNamespacedName, databaseUser)
+			Expect(err).ToNot(HaveOccurred())
+
+			// Update the username field
+			databaseUser.Spec.Username = "existing_user"
+			err = k8sClient.Update(ctx, databaseUser)
+			Expect(err).ToNot(HaveOccurred())
+
+			Eventually(func() string {
+				userObject := &DatabaseUser{}
+				err := k8sClient.Get(ctx, databaseNamespacedName, userObject)
+				Expect(err).NotTo(HaveOccurred())
+				return userObject.Status.Message
+			}).WithContext(ctx).Should(Equal("Ownership failed. Unable to update user."))
+
+			// Fetching again and checking the actual username.
+			databaseUser = &DatabaseUser{}
+			err = k8sClient.Get(ctx, databaseNamespacedName, databaseUser)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(databaseUser.Status.Username).To(Equal("orig-user-name"))
+
+		}, NodeTimeout(time.Second*30))
+
+		It("Allow Rename To Non-Existent User", func(ctx SpecContext) {
+
+			databaseNamespacedName := types.NamespacedName{
+				Name:      "switch-good-user",
+				Namespace: ServerAdminConnection.Namespace,
+			}
+
+			databaseUser := &DatabaseUser{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "switch-good-user",
+					Namespace: ServerAdminConnection.Namespace,
+				},
+				Spec: DatabaseUserSpec{
+					AdminConnection: AdminConnectionRef{
+						Name: ServerAdminConnection.Name,
+					},
+					Username: "existing_user",
+				},
+			}
+			err := k8sClient.Create(ctx, databaseUser)
+			Expect(err).ToNot(HaveOccurred())
+
+			Eventually(func() string {
+				userObject := &DatabaseUser{}
+				databaseNamespacedName := types.NamespacedName{
+					Namespace: databaseUser.Namespace,
+					Name:      databaseUser.Name,
+				}
+				err := k8sClient.Get(ctx, databaseNamespacedName, userObject)
+				Expect(err).ToNot(HaveOccurred())
+				return userObject.Status.Message
+			}).WithContext(ctx).Should(Equal("Invalid username specified."))
+
+			// Fetch a fresh DatabaseUser
+			databaseUser = &DatabaseUser{}
+			err = k8sClient.Get(ctx, databaseNamespacedName, databaseUser)
+			Expect(err).ToNot(HaveOccurred())
+
+			// Update the username field
+			databaseUser.Spec.Username = "switch-good-user"
+			err = k8sClient.Update(ctx, databaseUser)
+			Expect(err).ToNot(HaveOccurred())
+
+			Eventually(func() string {
+				userObject := &DatabaseUser{}
+				err := k8sClient.Get(ctx, databaseNamespacedName, userObject)
+				Expect(err).NotTo(HaveOccurred())
+				return userObject.Status.Message
+			}).WithContext(ctx).Should(Equal("Created user"))
+
+			// Fetching again and checking the actual username.
+			databaseUser = &DatabaseUser{}
+			err = k8sClient.Get(ctx, databaseNamespacedName, databaseUser)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(databaseUser.Status.Username).To(Equal("switch-good-user"))
+
+		}, NodeTimeout(time.Second*30))
+	})
 })


### PR DESCRIPTION
Made several changes to allow renaming usernames:

1. Ensure ownership of both existing and new username prior to RENAME command
2. Update zz_dba_operator table with updated name
3. Allow renames if the initial object was sitting on an invalid name (via CREATE, not rename)